### PR TITLE
Pin versions of sandpaper, pegboard, and varnish

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -75,5 +75,8 @@ profiles:
 #
 # This space below is where custom yaml items (e.g. pinning
 # sandpaper and varnish versions) should live
+sandpaper: astroDimitrios/sandpaper/tree/feature/tab-admonition
+pegboard: astroDimitrios/pegboard/tree/feature/tab-admonition
+varnish: astroDimitrios/varnish/tree/feature/all
 
 


### PR DESCRIPTION
Pinning these dependencies to my versions of these packages so we can user Mermaid, sphinx like tabs, and the Dark mode.
I think this will work! It does locally but I guess the real test is whether the GitHub pages deployment is happy with the pinned forks.