### PR TITLE
Add gfortran install link

### DIFF
--- a/links.md
+++ b/links.md
@@ -18,6 +18,8 @@ any links that you are not going to use.
 
 [this-course-link]: https://carpentries-incubator.github.io/intro-to-modern-fortran/
 
+[install-gfortran]: https://fortran-lang.org/learn/os_setup/install_gfortran/
+
 [emacs-link]: https://www.gnu.org/software/emacs/
 [emacs-init-link]: https://www.gnu.org/software/emacs/manual/html_node/emacs/Init-File.html
 


### PR DESCRIPTION
Fixes the broken link on the setup page for installing gfortran