### PR TITLE
Adds in a section on getting help and ai in the setup page

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -333,3 +333,78 @@ To add a ruler at 80 characters:
 
 Save the file.
 You should see a vertical line appear in your editor.
+
+## Getting Help
+
+There are many ways you can get help when stuck:
+
+- Search the internet: paste the last line of your error message and a short description of what you want to do into your favourite search engine.
+  You will usually find several examples where other people have encountered the same problem and came looking for help.
+  - [StackOverflow](https://stackoverflow.com/questions) has answers to questions which are presented with the most useful at the top.
+    You can search questions using the `[fortran]` tag in the search bar.
+  - Fortran-lang has a [discourse group](https://fortran-lang.discourse.group/) where you can ask questions.
+  - **Take care** copying and pasting code written by somebody else. This is risky unless you understand exactly what it is doing!
+- Ask somebody “in the real world”.
+  If you have a colleague or friend with more expertise than you have, show them the problem you are having and ask them for help.
+- Sometimes, the act of articulating your question can help you to identify what is going wrong.
+  This is known as [“rubber duck debugging”](https://en.wikipedia.org/wiki/Rubber_duck_debugging) among programmers.
+
+### Formulating your question
+
+The StackOverflow page on [how to ask a good question](https://stackoverflow.com/help/how-to-ask) has tips on what information to include when posting a question on StackOverflow. Some of these are specific to StackOverflow but others are also relevant if you're asking a colleague or friend for help, or even if just articulating your question to yourself.
+
+Ensure you include your compiler version in your question and full compiler output.
+
+### Generative AI
+
+::::::::::::::::::::::::::::: instructor
+
+### Choose how to include this section
+
+The section on generative AI is intended to be concise but Instructors may choose to devote more time to the topic in a workshop.
+
+Depending on your own level of experience and comfort with talking about and using these tools, you could choose to do any of the following:
+
+- Explain how large language models work and are trained, and/or the difference between generative AI, other forms of AI that currently exist, and the limits of what LLMs can do (e.g., they can't "reason").
+
+- Demonstrate how you recommend that learners use generative AI.
+
+- Discuss the ethical concerns listed below, as well as others that you are aware of, to help learners make an informed choice about whether or not to use generative AI tools.
+
+This is a fast-moving technology.
+If you are preparing to teach this section and you feel it has become outdated, please open an issue on the lesson repository to let the Maintainers know and/or a pull request to suggest updates and improvements.
+
+All instructors teaching this lesson ***should*** emphasise that AI
+is trained mainly on legacy Fortran and in many cases does not output useful answers.
+
+::::::::::::::::::::::::::::::::::::::::
+
+It is increasingly common for people to use ***generative AI*** chatbots such as ChatGPT to get help while coding.
+You will probably receive some useful guidance by presenting your error message to the chatbot and asking it what went wrong.
+However, the way this help is provided by the chatbot is different.
+Answers on StackOverflow have (probably) been given by a human as a direct response to the question asked.
+But generative AI chatbots, which are based on an advanced statistical model, respond by generating the ***most likely*** sequence of text that would follow the prompt they are given.
+
+While responses from generative AI tools can often be helpful, they are not always reliable.
+These tools sometimes generate plausible but incorrect or misleading information, so (just as with an answer found on the internet) it is essential to verify their accuracy.
+You need the knowledge and skills to be able to understand these responses, to judge whether or not they are accurate, and to fix any errors in the code it offers you.
+
+In addition to asking for help, programmers can use generative AI tools to generate code from scratch; extend, improve and reorganise existing code; translate code between programming languages; figure out what terms to use in a search of the internet; and more.
+However, there are drawbacks that you should be aware of.
+
+The models used by these tools have been “trained” on very large volumes of data, much of it taken from the internet, and the responses they produce reflect that training data, and may recapitulate its inaccuracies or biases.
+The environmental costs (energy and water use) of LLMs are a lot higher than other technologies, both during development (known as training) and when an individual user uses one (also called inference).
+For more information see the [AI Environmental Impact Primer](https://huggingface.co/blog/sasha/ai-environment-primer) developed by researchers at HuggingFace, an AI hosting platform.
+Concerns also exist about the way the data for this training was obtained, with questions raised about whether the people developing the LLMs had permission to use it.
+Other ethical concerns have also been raised, such as reports that workers were exploited during the training process.
+
+**We recommend that you avoid getting help from generative AI during the workshop** for several reasons:
+
+1. For most problems you will encounter at this stage, help and answers can be found among the first results returned by searching the internet.
+2. The foundational knowledge and skills you will learn in this lesson by writing and fixing your own programs are essential to be able to evaluate the correctness and safety of any code you receive from online help or a generative AI chatbot.
+  If you choose to use these tools in the future, the expertise you gain from learning and practising these fundamentals on your own will help you use them more effectively.
+3. As you start out with programming, the mistakes you make will be the kinds that have also been made – and overcome! – by everybody else who learned to program before you.
+   Since these mistakes and the questions you are likely to have at this stage are common, they are also better represented than other, more specialised problems and tasks in the data that was used to train generative AI tools.
+  This means that a generative AI chatbot is ***more likely to produce accurate responses*** to questions that novices ask, which could give you a false impression of how reliable they will be when you are ready to do things that are more advanced.
+4. The amount of modern Fortran code these tools are trained on is tiny compared to languages such as Python.
+   This means the tools will not be able to accurately generate modern Fortran.


### PR DESCRIPTION
Following other lessons and an effort by the Carpentries to include statements on AI I have added a getting help section to the end of the setup page which has info on the use of AI etc with slightly modified Carpentries text.

Examples of this being introduced in other Carpentries lessons:

- https://github.com/swcarpentry/r-novice-gapminder/pull/917/files
- https://github.com/swcarpentry/python-novice-gapminder/blob/main/episodes/04-built-in.md