### PR TITLE
Vim setup

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -287,9 +287,9 @@ This file is stored in your home directory.
 
 ### Vim
 
-[Vim](vim-link) is powerful customizable command-line text editor.  Fortran syntax highlighting and indenting are present by default.
+[Vim][vim-link] is powerful customizable command-line text editor.  Fortran syntax highlighting and indenting are present by default.
 
-To add additional Fortran features including syntax checking, linting, and keyboard shortcuts, install vim plugin [vimf90](vimf90-link)
+To add additional Fortran features including syntax checking, linting, and keyboard shortcuts, install vim plugin [vimf90][vimf90-link]
 by following the instructions for Vundle or another vim plugin manager.
 
 ### VS Code

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -289,8 +289,9 @@ This file is stored in your home directory.
 
 [Vim][vim-link] is powerful customizable command-line text editor.  Fortran syntax highlighting and indenting are present by default.
 
-To add additional Fortran features including syntax checking, linting, and keyboard shortcuts, install vim plugin [vimf90][vimf90-link]
-by following the instructions for Vundle or another vim plugin manager.
+To add additional Fortran features including syntax checking, linting, and keyboard shortcuts,
+install the Vim plugin [vimf90][vimf90-link]
+by following the instructions for Vundle or another Vim plugin manager.
 
 ### VS Code
 

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -100,7 +100,7 @@ Comprehensive installation instructions are on the
 
 Check whether GFortran is already installed:
 
-```bash 
+```bash
 $ gfortran --version
 ```
 
@@ -112,9 +112,9 @@ For example on Debian or Ubuntu (note that this requires root access):
 $ sudo apt install gfortran
 ```
 
-See [the website][install-gfortran] for instructions for other operating systems. 
+See [the website][install-gfortran] for instructions for other operating systems.
 
-Without root access, 
+Without root access,
 you can install GFortran locally with [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html):
 
 ```bash
@@ -244,6 +244,7 @@ Setup instructions for some editors are available below.
 Editor Setup Quick Links:
 
 - [Emacs](#emacs)
+- [Vim](#vim)
 - [VS Code](#vs-code)
 
 ### Emacs
@@ -283,6 +284,25 @@ The `.emacs` or `.emacs.el` file is an older method of configuring Emacs.
 This file is stored in your home directory.
 
 :::::::::::::::::::::::::
+
+### Vim
+[Vim](vim-link) is a text editor.  Fortran syntax highlighting and indenting is present by default.
+
+Since fortran is case-insensitive, set vim's search to `ic` (ignore case) by adding to `~/.vimrc`
+```
+set ic
+set incsearch
+```
+
+To set vim to remember what line we were on when opening files, add the following to `~/.vimrc`:
+```
+" Remember cursor position
+if has("autocmd")
+  au BufReadPost * if line("'\"") > 1 && line("'\"") <= line("$") | execute "normal! g`\"" | endif
+endif
+```
+
+
 
 ### VS Code
 

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -286,23 +286,11 @@ This file is stored in your home directory.
 :::::::::::::::::::::::::
 
 ### Vim
-[Vim](vim-link) is a text editor.  Fortran syntax highlighting and indenting is present by default.
 
-Since fortran is case-insensitive, set vim's search to `ic` (ignore case) by adding to `~/.vimrc`
-```
-set ic
-set incsearch
-```
+[Vim](vim-link) is powerful customizable command-line text editor.  Fortran syntax highlighting and indenting are present by default.
 
-To set vim to remember what line we were on when opening files, add the following to `~/.vimrc`:
-```
-" Remember cursor position
-if has("autocmd")
-  au BufReadPost * if line("'\"") > 1 && line("'\"") <= line("$") | execute "normal! g`\"" | endif
-endif
-```
-
-
+To add additional Fortran features including syntax checking, linting, and keyboard shortcuts, install vim plugin [vimf90](vimf90-link)
+by following the instructions for Vundle or another vim plugin manager.
 
 ### VS Code
 

--- a/links.md
+++ b/links.md
@@ -23,5 +23,8 @@ any links that you are not going to use.
 [emacs-link]: https://www.gnu.org/software/emacs/
 [emacs-init-link]: https://www.gnu.org/software/emacs/manual/html_node/emacs/Init-File.html
 
+[vim-link]: https://www.vim.org/
+[vimf09-link]: https://rudrab.github.io/vimf90/
+
 [vscode-link]: https://code.visualstudio.com
 [vscode-modern-fortran]: https://marketplace.visualstudio.com/items?itemName=fortran-lang.linter-gfortran

--- a/links.md
+++ b/links.md
@@ -24,7 +24,7 @@ any links that you are not going to use.
 [emacs-init-link]: https://www.gnu.org/software/emacs/manual/html_node/emacs/Init-File.html
 
 [vim-link]: https://www.vim.org/
-[vimf09-link]: https://rudrab.github.io/vimf90/
+[vimf90-link]: https://rudrab.github.io/vimf90/
 
 [vscode-link]: https://code.visualstudio.com
 [vscode-modern-fortran]: https://marketplace.visualstudio.com/items?itemName=fortran-lang.linter-gfortran


### PR DESCRIPTION
Short basic version

I also had these ideas, which I consider essential:

> 
> Since fortran is case-insensitive, set vim's search to `ic` (ignore case) by adding to `~/.vimrc`
> ```
> set ic
> ```
> 
> To set vim to remember what line we were on when opening files, add the following to `~/.vimrc`: 
> ```
> " Remember cursor position
> if has("autocmd")
>   au BufReadPost * if line("'\"") > 1 && line("'\"") <= line("$") | execute "normal! g`\"" | endif
> endif
> ```
> 

Thoughts?